### PR TITLE
Sets include to FALSE in Rmd setup blocks

### DIFF
--- a/vignettes/pathogen_lassa.Rmd
+++ b/vignettes/pathogen_lassa.Rmd
@@ -28,7 +28,7 @@ All Figures from the paper are re-produced below on the **latest** available dat
 }
 ```
 
-```{r setup, echo=FALSE, message=FALSE, warning=FALSE}
+```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = FALSE)
 
 source(file.path("..", "shared", "lassa_functions.R"))

--- a/vignettes/pathogen_marburg.Rmd
+++ b/vignettes/pathogen_marburg.Rmd
@@ -27,7 +27,7 @@ All Tables and Figures from the paper are re-produced below on the **latest** av
 ```
 
 
-```{r setup, echo=FALSE, message=FALSE, warning=FALSE}
+```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = FALSE)
 remotes::install_github("mrc-ide/epireview@v0.1.0")
 library(epireview)


### PR DESCRIPTION
- Unwanted output from the remotes install statement was included in the html. This change removes the output.