### PR TITLE
Fix some formating in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ downloaded using the `-l` flag. On the command line, type the following:
 ```
 Rscript ebola_workflow.R -l ~/Downloads
 ```
-``~/Downloads'' should be replaced by the full path of the folder where you wish to download the outputs. Note that this
-*** location should not be a sub-folder of the priority-pathogens repo ***.
+
+`~/Downloads` should be replaced by the full path of the folder where you wish to download the outputs. Note that this
+**location should not be a sub-folder of the priority-pathogens repo**.
 The script will then download the outputs, configure the orderly project and run ebola analysis tasks sequentially. 
-* Note that the tasks create and save a number of images and word documents, and will take a long time to finish. *
+**Note that the tasks create and save a number of images and word documents, and will take a long time to finish.**

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ consists of a set of ``orderly tasks'' in the src folder that make up our analyt
 the pipeline (`db_extraction`, `db_double`, and `db_compilation`) read in the Access databases, clean, and compile a 
 clean dataset for downstream analysis. These tasks need access to the database files stored on Imperial's internal 
 network. Since an external user cannot run these tasks, we provide the outputs of these tasks with the associated 
-Github release. These outputs must be downloaded and `made visible' to the orderly project for the rest of the code
+Github release. These outputs must be downloaded and "made visible" to the orderly project for the rest of the code
 to work. The R script `ebola_workflow.R` will download the outputs and do the necessary configuration for this to
 happen. To run the script, 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # pkgdown <img src="man/figures/logo.png" align="right" />
 
 The priority-pathogens repository is an [orderly](https://mrc-ide.github.io/orderly2/) project. The repository
-consists of a set of ``orderly tasks'' in the src folder that make up our analytical pipeline. The first three tasks in 
+consists of a set of "orderly tasks" in the src folder that make up our analytical pipeline. The first three tasks in 
 the pipeline (`db_extraction`, `db_double`, and `db_compilation`) read in the Access databases, clean, and compile a 
 clean dataset for downstream analysis. These tasks need access to the database files stored on Imperial's internal 
 network. Since an external user cannot run these tasks, we provide the outputs of these tasks with the associated 


### PR DESCRIPTION
This fixes some formatting errors with use of ", `, and *.