### PR TITLE
Addresses issue #61 & RedCAP POST graceful fail

### DIFF
--- a/src/db_extraction_prep/db_extraction_prep.R
+++ b/src/db_extraction_prep/db_extraction_prep.R
@@ -1,7 +1,8 @@
 library(orderly2)
 
 orderly_parameters(pathogen = NULL,
-                   mode="")
+                   mode="",
+                   orderly_download_depencency=FALSE)
 
 pathogen <- toupper(pathogen)
 mode <- toupper(mode)

--- a/src/db_extraction_prep/db_extraction_prep.R
+++ b/src/db_extraction_prep/db_extraction_prep.R
@@ -2,7 +2,7 @@ library(orderly2)
 
 orderly_parameters(pathogen = NULL,
                    mode="",
-                   orderly_download_depencency=FALSE)
+                   orderly_download_dependency=FALSE)
 
 pathogen <- toupper(pathogen)
 mode <- toupper(mode)

--- a/src/db_extraction_prep/prepare_redcap.R
+++ b/src/db_extraction_prep/prepare_redcap.R
@@ -576,7 +576,7 @@ orderly_resource(c(config_file_path))
 # Shared resources are assigned dynamically based on config file, so it is
 # loaded in the orderly config section
 config_list <- yaml.load_file(config_file_path)
-orderly_download_depencency <- config_list[["orderly_download_depencency"]]
+
 # Note: table_filenames_vec needs to be a named vector, with names corresponding
 # to config_list[["table_filepaths"]] names
 if (orderly_download_depencency==TRUE){

--- a/src/db_extraction_prep/prepare_redcap.R
+++ b/src/db_extraction_prep/prepare_redcap.R
@@ -579,7 +579,7 @@ config_list <- yaml.load_file(config_file_path)
 
 # Note: table_filenames_vec needs to be a named vector, with names corresponding
 # to config_list[["table_filepaths"]] names
-if (orderly_download_depencency==TRUE){
+if (orderly_download_dependency==TRUE){
   table_filenames_vec <- unlist(config_list[["table_filepaths"]])
 
   orderly_dependency(

--- a/src/db_extraction_prep/redcap_task/nipah/config.yaml
+++ b/src/db_extraction_prep/redcap_task/nipah/config.yaml
@@ -10,7 +10,6 @@
     "incomplete_col": "pathogen_epidemiology_review_complete"
 "target_filepath": "redcap_data/table_target.csv"
 "mapping_filepath": "redcap_data/nipah/mapping_table.csv"
-orderly_download_depencency: true
 "table_filepaths":
     "all_data": "nipah_raw_data.csv"
 "linked_row_col_names":

--- a/src/db_redcap_download/db_redcap_download.R
+++ b/src/db_redcap_download/db_redcap_download.R
@@ -43,13 +43,17 @@ for (report_id in names(report_id_list)){
   response <-
     tryCatch(stop_for_status(POST(endpoint_url, body = post_body_list, encode = "form")),
            http_404 = function(e) cli_abort(
-             c("404 Not Found", exit_text)),
+             c("404 Not Found", exit_text),
+             call=NULL),
            http_403 = function(e) cli_abort(
-             c("403 Forbidden - check your auth token!", exit_text)),
+             c("403 Forbidden - check your auth token!", exit_text),
+             call=NULL),
            http_400 = function(e) cli_abort(
-             c("400 Bad Request", exit_text)),
+             c("400 Bad Request", exit_text),
+             call=NULL),
            http_500 = function(e) cli_abort(
-             c("500 Internal Server Error", exit_text)),
+             c("500 Internal Server Error", exit_text),
+             call=NULL),
            error = function(e) cli_abort(
              c(e$message, exit_text), call = e$call)
   )


### PR DESCRIPTION
Addresses #61 by creating the orderly parameter `orderly_download_dependency` in `db_extraction_prep`.
Additionally, adds error catching the `db_redcap_download` POST calls so that the error messages are more informative and so that it gracefully fails.