### PR TITLE
Improves form merging, cli output, & table mapping

### DIFF
--- a/shared/redcap_data/nipah/mapping_table.csv
+++ b/shared/redcap_data/nipah/mapping_table.csv
@@ -54,14 +54,14 @@ parameter_range_low,parameters,Parameter lower bound,parameters
 parameter_range_upper,parameters,Parameter upper bound,parameters
 parameter_value_type,parameters,Parameter value type,parameters
 parameter_unc_single_type,parameters,Parameter uncertainty - single value,parameters
-parameter_unc_single_value,parameters,Parameter uncertainty - singe type,parameters
+parameter_unc_single_value,parameters,Parameter uncertainty - single type,parameters
 parameter_unc_pair_value_low,parameters,Parameter uncertainty - lower value,parameters
 parameter_unc_pair_value_up,parameters,Parameter uncertainty - upper value,parameters
 parameter_unc_pair_type,parameters,Parameter uncertainty - type,parameters
 parameter_cfr_num,parameters,CFR_IFR_numerator,parameters
 parameter_cfr_denom,parameters,CFR_IFR_denominator,parameters
-parameter_distribution_type,parameters,Distribution_type,parameters
-parameter_distribution_value,parameters,Distribution_par1_value,parameters
+parameter_distribution_type,parameters,,parameters
+parameter_distribution_value,parameters,,parameters
 parameter_supplement,parameters,Method_from_supplement,parameters
 parameter_cfr_method,parameters,CFR_IFR_Method,parameters
 parameter_r_method,parameters,Method_R,parameters
@@ -92,22 +92,22 @@ parameter_figure,parameters,Parameter_FromFigure,parameters
 parameter_r_pathway,parameters,R_pathway,parameters
 parameter_exponent,parameters,Exponent,parameters
 article_preprint,articles,,articles
-outbreak_unspecified,outbreaks,,outbreaks
-outbreak_population_size,outbreaks,,outbreaks
-outbreak_sex,outbreaks,,outbreaks
-outbreak_males,outbreaks,,outbreaks
-outbreak_proportion_males,outbreaks,,outbreaks
-outbreak_females,outbreaks,,outbreaks
-outbreak_proportion_females,outbreaks,,outbreaks
-parameter_statistical,parameters,,parameters
+outbreak_unspecified,outbreaks,Cases_unspecified,outbreaks
+outbreak_population_size,outbreaks,Population_size,outbreaks
+outbreak_sex,outbreaks,Type_cases_sex_disagg,outbreaks
+outbreak_males,outbreaks,Male_cases,outbreaks
+outbreak_proportion_males,outbreaks,Prop_male_cases,outbreaks
+outbreak_females,outbreaks,Female_cases,outbreaks
+outbreak_proportion_females,outbreaks,Prop_female_cases,outbreaks
+parameter_statistical,parameters,Parameter statistical approach,parameters
 parameter_paired,parameters,,parameters
 parameter_hd_from,parameters,,parameters
 parameter_hd_to,parameters,,parameters
-parameter_cfr_definition,parameters,,parameters
-parameter_cfr_seroprev,parameters,,parameters
-parameter_context_timing,parameters,,parameters
-parameter_context_urban,parameters,,parameters
-parameter_context_data,parameters,,parameters
+parameter_cfr_definition,parameters,Case_definition,parameters
+parameter_cfr_seroprev,parameters,seroprevalence_adjusted,parameters
+parameter_context_timing,parameters,Method_moment_value,parameters
+parameter_context_urban,parameters,Urban/Rural area,parameters
+parameter_context_data,parameters,Data_available,parameters
 article_presto,articles,,articles
 model_compartmental_other,models,,models
 model_notes,models,,models
@@ -117,21 +117,39 @@ parameter_notes,parameters,,parameters
 qa_notes,articles,,articles
 parameter_context_location_type,parameters,,parameters
 parameter_pair_type,parameters,,parameters
-parameter_pair_value,parameters,,parameters
-parameter_pair_exponent,parameters,,parameters
-parameter_pair_range_low,parameters,,parameters
-parameter_pair_range_up,parameters,,parameters
-parameter_pair_inverse,parameters,,parameters
-parameter_pair_unit,parameters,,parameters
+parameter_pair_value,parameters,Parameter 2 value,parameters
+parameter_pair_exponent,parameters,Exponent_2,parameters
+parameter_pair_range_low,parameters,Parameter 2 lower bound,parameters
+parameter_pair_range_up,parameters,Parameter 2 upper bound,parameters
+parameter_pair_inverse,parameters,Inverse_param_2,parameters
+parameter_pair_unit,parameters,Parameter 2 unit,parameters
 parameter_pair_value_type,parameters,,parameters
-parameter_pair_supplement,parameters,,parameters
-parameter_pair_statistical,parameters,,parameters
-parameter_pair_unc_single_value,parameters,,parameters
-parameter_pair_unc_pair_type,parameters,,parameters
-parameter_pair_unc_pair_value_low,parameters,,parameters
-parameter_pair_unc_pair_value_up,parameters,,parameters
+parameter_pair_supplement,parameters,Method_2_from_supplement,parameters
+parameter_pair_statistical,parameters,Parameter 2 statistical approach,parameters
+parameter_pair_unc_single_value,parameters,Parameter 2 uncertainty - single value,parameters
+parameter_pair_unc_pair_type,parameters,Parameter 2 uncertainty – type,parameters
+parameter_pair_unc_pair_value_low,parameters,Parameter 2 uncertainty - lower value,parameters
+parameter_pair_unc_pair_value_up,parameters,Parameter 2 uncertainty - upper value,parameters
 parameter_pair_distribution_type,parameters,,parameters
 parameter_pair_distribution_value,parameters,,parameters
+parameter_distr_type,parameters,Distribution_type,parameters
+parameter_distr_a_type,parameters,Distribution_par1_type,parameters
+parameter_distr_a_value,parameters,Distribution_par1_value,parameters
+parameter_distr_b_type,parameters,Distribution_par2_type,parameters
+parameter_distr_b_value,parameters,Distribution_par2_value,parameters
+parameter_distr_b_uncertainty,parameters,Distribution_par2_uncertainty,parameters
+parameter_pair_sp,parameters,Parameter 2 value type,parameters
+parameter_pair_pair_low,parameters,Parameter_2_sample_paired_upper,parameters
+parameter_pair_pair_up,parameters,Parameter_2_sample_paired_lower,parameters
+parameter_pair_distr_type,parameters,Distribution_2_type,parameters
+parameter_pair_distr_a_type,parameters,Distribution_2_par1_type,parameters
+parameter_pair_distr_a_value,parameters,Distribution_2_par1_value,parameters
+parameter_pair_distr_b_type,parameters,Distribution_2_par2_type,parameters
+parameter_pair_distr_b_value,parameters,Distribution_2_par2_value,parameters
+parameter_pair_distr_b_uncertainty,parameters,Distribution_2_par2_uncertainty,parameters
+parameter_distr_a_uncertainty,parameters,Distribution_par1_uncertainty,parameters
+parameter_pair_unc_single_type,parameters,Parameter 2 uncertainty - single type,parameters
+parameter_pair_distr_a_uncertainty,parameters,Distribution_2_par1_uncertainty,parameters
 outbreak_notes,outbreaks,,outbreaks
 model_uncertainty,models,,models
 model_spillover,models,,models

--- a/shared/redcap_data/nipah/mapping_table.csv
+++ b/shared/redcap_data/nipah/mapping_table.csv
@@ -53,8 +53,8 @@ parameter_unit,parameters,Parameter unit,parameters
 parameter_range_low,parameters,Parameter lower bound,parameters
 parameter_range_upper,parameters,Parameter upper bound,parameters
 parameter_value_type,parameters,Parameter value type,parameters
-parameter_unc_single_type,parameters,Parameter uncertainty - single value,parameters
-parameter_unc_single_value,parameters,Parameter uncertainty - single type,parameters
+parameter_unc_single_type,parameters,Parameter uncertainty - single type,parameters
+parameter_unc_single_value,parameters,Parameter uncertainty - single value,parameters
 parameter_unc_pair_value_low,parameters,Parameter uncertainty - lower value,parameters
 parameter_unc_pair_value_up,parameters,Parameter uncertainty - upper value,parameters
 parameter_unc_pair_type,parameters,Parameter uncertainty - type,parameters

--- a/shared/redcap_data/nipah/mapping_table.csv
+++ b/shared/redcap_data/nipah/mapping_table.csv
@@ -151,6 +151,7 @@ parameter_distr_a_uncertainty,parameters,Distribution_par1_uncertainty,parameter
 parameter_pair_unc_single_type,parameters,Parameter 2 uncertainty - single type,parameters
 parameter_pair_distr_a_uncertainty,parameters,Distribution_2_par1_uncertainty,parameters
 outbreak_notes,outbreaks,,outbreaks
+outbreak_probable,outbreaks,,outbreaks
 model_uncertainty,models,,models
 model_spillover,models,,models
 model_fitting_method,models,,models

--- a/shared/redcap_data/nipah/mapping_table.csv
+++ b/shared/redcap_data/nipah/mapping_table.csv
@@ -60,8 +60,6 @@ parameter_unc_pair_value_up,parameters,Parameter uncertainty - upper value,param
 parameter_unc_pair_type,parameters,Parameter uncertainty - type,parameters
 parameter_cfr_num,parameters,CFR_IFR_numerator,parameters
 parameter_cfr_denom,parameters,CFR_IFR_denominator,parameters
-parameter_distribution_type,parameters,,parameters
-parameter_distribution_value,parameters,,parameters
 parameter_supplement,parameters,Method_from_supplement,parameters
 parameter_cfr_method,parameters,CFR_IFR_Method,parameters
 parameter_r_method,parameters,Method_R,parameters
@@ -116,22 +114,18 @@ outbreak_source,outbreaks,,outbreaks
 parameter_notes,parameters,,parameters
 qa_notes,articles,,articles
 parameter_context_location_type,parameters,,parameters
-parameter_pair_type,parameters,,parameters
 parameter_pair_value,parameters,Parameter 2 value,parameters
 parameter_pair_exponent,parameters,Exponent_2,parameters
 parameter_pair_range_low,parameters,Parameter 2 lower bound,parameters
 parameter_pair_range_up,parameters,Parameter 2 upper bound,parameters
 parameter_pair_inverse,parameters,Inverse_param_2,parameters
 parameter_pair_unit,parameters,Parameter 2 unit,parameters
-parameter_pair_value_type,parameters,,parameters
 parameter_pair_supplement,parameters,Method_2_from_supplement,parameters
 parameter_pair_statistical,parameters,Parameter 2 statistical approach,parameters
 parameter_pair_unc_single_value,parameters,Parameter 2 uncertainty - single value,parameters
 parameter_pair_unc_pair_type,parameters,Parameter 2 uncertainty – type,parameters
 parameter_pair_unc_pair_value_low,parameters,Parameter 2 uncertainty - lower value,parameters
 parameter_pair_unc_pair_value_up,parameters,Parameter 2 uncertainty - upper value,parameters
-parameter_pair_distribution_type,parameters,,parameters
-parameter_pair_distribution_value,parameters,,parameters
 parameter_distr_type,parameters,Distribution_type,parameters
 parameter_distr_a_type,parameters,Distribution_par1_type,parameters
 parameter_distr_a_value,parameters,Distribution_par1_value,parameters

--- a/shared/redcap_data/table_target.csv
+++ b/shared/redcap_data/table_target.csv
@@ -49,7 +49,7 @@ Parameter lower bound,parameters
 Parameter upper bound,parameters
 Parameter value type,parameters
 Parameter uncertainty - single value,parameters
-Parameter uncertainty - singe type,parameters
+Parameter uncertainty - single type,parameters
 Parameter uncertainty - lower value,parameters
 Parameter uncertainty - upper value,parameters
 Parameter uncertainty - type,parameters
@@ -126,3 +126,40 @@ ID,outbreaks
 Pathogen,outbreaks
 Covidence_ID,outbreaks
 Name_data_entry,outbreaks
+Distribution_2_type,parameters
+Distribution_2_par2_value,parameters
+Distribution_2_par2_uncertainty,parameters
+Distribution_2_par2_type,parameters
+Distribution_2_par1_value,parameters
+Distribution_2_par1_uncertainty,parameters
+Distribution_2_par1_type,parameters
+Data_available,parameters
+Case_definition,parameters
+Exponent_2,parameters
+Method_2_from_supplement,parameters
+Inverse_param_2,parameters
+Parameter 2 value type,parameters
+Parameter 2 value,parameters
+Parameter 2 upper bound,parameters
+Parameter 2 unit,parameters
+Parameter 2 uncertainty - upper value,parameters
+Parameter 2 uncertainty - type,parameters
+Parameter 2 uncertainty - single value,parameters
+Parameter 2 uncertainty - single type,parameters
+Parameter 2 uncertainty - lower value,parameters
+Parameter 2 statistical approach,parameters
+Parameter_2_sample_paired_upper,parameters
+Parameter_2_sample_paired_lower,parameters
+Parameter 2 lower bound,parameters
+Urban/Rural area,parameters
+Trimester_exposed,parameters
+Third_sample_param_yn,parameters
+seroprevalence_adjusted,parameters
+Parameter statistical approach,parameters
+Female_cases,outbreaks
+Male_cases,outbreaks
+Population_size,outbreaks
+Prop_female_cases,outbreaks
+Prop_male_cases,outbreaks
+Type_cases_sex_disagg,outbreaks
+Cases_unspecified,outbreaks

--- a/src/db_extraction_prep/prepare_redcap.R
+++ b/src/db_extraction_prep/prepare_redcap.R
@@ -249,10 +249,10 @@ get_overflow_mapping_table <- function(df,
     id_mapping_list[[as.character(id_to_map_to)]] <- id_update_vec
 
     cli_alert_info(
-      paste0(extractor, " has indicated that Covidence ID:", cov_id,
+      paste0(extractor, " has indicated that Covidence ID: ", cov_id,
             " is a continuation. There are ", NROW(temp_df), " REDCap entries with this ID.\n",
             "The following ", id_col, " will be mapped to ", id_to_map_to, ": ",
-            paste(id_update_vec, collapse=","))
+            paste(id_update_vec, collapse=", "))
     )
 
   }
@@ -275,7 +275,7 @@ generate_target_table <- function(input_df_list, mapping_df, target_table,
                                   target_table_col_name="target_table",
                                   input_col_name = "input_col",
                                   target_col_name = "target_col"){
-  cli_inform(paste("Generating table:", target_table))
+  cli_h3(paste("Generating table:", target_table))
 
   mapping_non_na_df <- mapping_df[!is.na(mapping_df[target_table_col_name]), ]
   filtered_mapping_df <- (mapping_non_na_df[
@@ -648,7 +648,7 @@ article_cols_to_add_start <- config_list[["article_cols_to_add_start"]]
 article_cols_to_add_end <- config_list[["article_cols_to_add_end"]]
 
 # *------------------------------- Read in data -------------------------------*
-mapping_df <- read_csv(mapping_filename)
+mapping_df <- read_csv(mapping_filename, show_col_types = FALSE)
 
 if (!is.null(table_instrument_source_list)){
   mapping_df <- col_list_key_map(df=mapping_df,
@@ -656,9 +656,10 @@ if (!is.null(table_instrument_source_list)){
                                  mapping_list=table_instrument_source_list)
 }
 
-target_names_df <- read_csv(target_filename)
+target_names_df <- read_csv(target_filename, show_col_types = FALSE)
 
-df_raw_list <- lapply(table_filenames_vec, function(x) read_csv(x))
+df_raw_list <- lapply(table_filenames_vec,
+                      function(x) read_csv(x, show_col_types = FALSE))
 
 cli_h1("Comparing REDCap input and mapping file")
 check_raw_cols_mapping(df_raw_list, mapping_df, tables_to_stack,

--- a/src/db_extraction_prep/prepare_redcap.R
+++ b/src/db_extraction_prep/prepare_redcap.R
@@ -63,7 +63,9 @@ filter_record_ids <- function(df, record_id_vec, name, cli_text){
 get_not_pathogen_ids <- function(df, pathogen, id_col, pathogen_col="pathogen"){
   # Update for Pathogen other
   pathogen_lower_vec <- sapply(df[pathogen_col], tolower)
-  record_vec <- df[pathogen_lower_vec!=tolower(pathogen), ][[id_col]]
+  not_pathogen_filter <- (pathogen_lower_vec!=tolower(pathogen) |
+                            is.na(pathogen_lower_vec))
+  record_vec <- df[not_pathogen_filter, ][[id_col]]
   record_vec <- unique(record_vec)
   return (record_vec)
 }

--- a/src/db_extraction_prep/prepare_redcap.R
+++ b/src/db_extraction_prep/prepare_redcap.R
@@ -220,6 +220,7 @@ get_overflow_mapping_table <- function(df,
   non_na_df <- df[!is.na(df[[extractor_col]]) & !is.na(df[[cov_id_col]]), ]
   continuations_df <- non_na_df[!is.na(non_na_df[[continuation_col]]),
                                 c(cov_id_col, extractor_col)]
+  continuations_df <- unique(continuations_df)
 
   id_mapping_list <- list()
 

--- a/src/db_extraction_prep/redcap_task/nipah/config.yaml
+++ b/src/db_extraction_prep/redcap_task/nipah/config.yaml
@@ -8,6 +8,7 @@
     "continuation_col": "article_continuation"
     "extractor_col": "extractor_name"
     "incomplete_col": "pathogen_epidemiology_review_complete"
+    "notes_cols": ["article_notes", "qa_notes"]
 "target_filepath": "redcap_data/table_target.csv"
 "mapping_filepath": "redcap_data/nipah/mapping_table.csv"
 "table_filepaths":
@@ -18,6 +19,7 @@
     "parameters": "parameter_linked"
 "incomplete_col_names":
     "articles": "pathogen_epidemiology_review_complete"
+"incomplete_col_key": "Incomplete"
 "target_table_names": ["articles", "models", "outbreaks", "parameters"]
 "data_table_names": ["models", "outbreaks", "parameters"]
 "pk_col_names":


### PR DESCRIPTION
Adds smarter merging of articles when there are form continuations.
Updates the mapping_table using Zika raw column names, reflecting the REDCap uncertainty-capturing update.
Fixes Pathogen filtering bug - NA pathogen columns were erroneously included. 
Improves cli output of prepare_redcap. 