### PR TITLE
Updates pk creation & adds merging to process log

### DIFF
--- a/src/db_extraction_prep/prepare_redcap.R
+++ b/src/db_extraction_prep/prepare_redcap.R
@@ -713,7 +713,6 @@ pk_col_names <- config_list[["pk_col_names"]]
 pk_base_id <- config_list[["pk_base_id"]]
 
 date_cols_to_split <- config_list[["date_cols_to_split"]]
-article_add_sort_cols <- config_list[["article_add_sort_cols"]]
 article_cols_to_add_start <- config_list[["article_cols_to_add_start"]]
 article_cols_to_add_end <- config_list[["article_cols_to_add_end"]]
 
@@ -1021,10 +1020,9 @@ if (!is.null(pk_col_names)){
 if (!is.null(uuid_col_names)){
   # Order by ArticleID and additional cols to ensure uuid is always assigned
   # in the same order
-  article_sort_cols <- c(article_id, article_add_sort_cols)
   sort_order <- do.call(
     what = order,
-    args = target_df_clean_list[[continuation_table]][,article_sort_cols])
+    args = target_df_clean_list[[continuation_table]][,article_id])
   target_df_clean_list[[continuation_table]] <-
     target_df_clean_list[[continuation_table]][sort_order, ]
 

--- a/src/db_extraction_prep/prepare_redcap.R
+++ b/src/db_extraction_prep/prepare_redcap.R
@@ -1018,6 +1018,7 @@ if (!is.null(pk_col_names)){
 
 # Add UUID columns
 if (!is.null(uuid_col_names)){
+  set.seed(3141)
   # Order by ArticleID and additional cols to ensure uuid is always assigned
   # in the same order
   sort_order <- do.call(

--- a/src/db_extraction_prep/prepare_redcap.R
+++ b/src/db_extraction_prep/prepare_redcap.R
@@ -986,8 +986,9 @@ target_df_raw_list <- setNames(
   target_table_names)
 
 # *------------------------------ Process target ------------------------------*
-# Split date columns into day, month, year
 target_df_clean_list <- target_df_raw_list
+
+# Split date columns into day, month, year
 if (!is.null(date_cols_to_split)){
   cli_h1("Expanding date columns")
   for (name in names(date_cols_to_split)){

--- a/src/db_extraction_prep/redcap_task/nipah/config.yaml
+++ b/src/db_extraction_prep/redcap_task/nipah/config.yaml
@@ -34,7 +34,6 @@ date_cols_to_split:
     "outbreaks": "Outbreak_data_ID"
     "parameters": "Parameter_data_ID"
     "models": "Model_data_ID"
-"article_add_sort_cols": ["Name_data_entry"]
 "article_cols_to_add_end": ["Pathogen", "ID"]
 "article_cols_to_add_start": [ "Covidence_ID", "Name_data_entry"]
 "article_id": "Article_ID"

--- a/src/db_extraction_prep/redcap_task/nipah/config.yaml
+++ b/src/db_extraction_prep/redcap_task/nipah/config.yaml
@@ -34,7 +34,9 @@ date_cols_to_split:
     "outbreaks": "Outbreak_data_ID"
     "parameters": "Parameter_data_ID"
     "models": "Model_data_ID"
-article_cols_to_add_end: ["Pathogen", "ID"]
-article_cols_to_add_start: [ "Covidence_ID", "Name_data_entry"]
+"article_add_sort_cols": ["Name_data_entry"]
+"article_cols_to_add_end": ["Pathogen", "ID"]
+"article_cols_to_add_start": [ "Covidence_ID", "Name_data_entry"]
+"article_id": "Article_ID"
 ---
 


### PR DESCRIPTION
This PR combines two updates (sorry!)

1. It adds the details of which article ids were updated due to being extracted over multiple forms to the process report and cleans the cli output related to form continuations. 
2. It updates the creation of the  [table]_access_id primary keys (pks). These are used so that downstream orderly tasks are compatible with data extracted using REDCap.

Due to the format of the REDCap data, the only unique identifier is the record_id (which gets renamed to Article_ID). Previously, the  [table]_access_id pks were created as auto-incrementing integers, on the assumption that the data were ordered by time. However, this assumption was incorrect. Consequently, if new data is extracted using an existing form, the  [table]_access_id may change. This is problematic since these ids are needed by the fixed double extraction files when merging them to the matching and single extraction files.

The solution is assign an id based on the unique record id and the order of extraction of the data in REDCap, i.e. `record_id_extraction_number`.  A potential flaw with this approach is that we will be unable to know someone deletes a record and then recreates a record in its place - however, this seems like an edge case.

The ideal solution would be to assign a primary key to every outbreak, model, and parameter instance in REDCap and to use that instead of the [table]_access_id throughout the code base. 